### PR TITLE
Change SWM logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Docs can be found at <https://hexdocs.pm/membrane_element_rtp_mpegaudio>.
 
 Copyright 2018, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)
 
-[![Software Mansion](https://membraneframework.github.io/static/logo/swm_logo_readme.png)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)


### PR DESCRIPTION
<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>